### PR TITLE
feat: oEmbed spec 가져오기 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nestjs/axios": "^0.0.3",
         "@nestjs/common": "^8.0.0",
         "@nestjs/core": "^8.0.0",
         "@nestjs/platform-express": "^8.0.0",
@@ -1264,6 +1265,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@nestjs/axios": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-0.0.3.tgz",
+      "integrity": "sha512-Cc+D2S2uesthRpalmZEPdm5wF2N9ji4l9Wsb2vFaug/CVWg2BoegHm0L1jzFUL+6kS+mXWSFvwXJmofv+7bajw==",
+      "dependencies": {
+        "axios": "0.23.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0",
+        "reflect-metadata": "^0.1.12",
+        "rxjs": "^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@nestjs/axios/node_modules/axios": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.23.0.tgz",
+      "integrity": "sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
       }
     },
     "node_modules/@nestjs/cli": {
@@ -9768,6 +9790,24 @@
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
+          }
+        }
+      }
+    },
+    "@nestjs/axios": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-0.0.3.tgz",
+      "integrity": "sha512-Cc+D2S2uesthRpalmZEPdm5wF2N9ji4l9Wsb2vFaug/CVWg2BoegHm0L1jzFUL+6kS+mXWSFvwXJmofv+7bajw==",
+      "requires": {
+        "axios": "0.23.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.23.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.23.0.tgz",
+          "integrity": "sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==",
+          "requires": {
+            "follow-redirects": "^1.14.4"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@nestjs/axios": "^0.0.3",
     "@nestjs/common": "^8.0.0",
     "@nestjs/core": "^8.0.0",
     "@nestjs/platform-express": "^8.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
+
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { OembedModule } from './oembed/oembed.module';
 
 @Module({
-  imports: [],
+  imports: [OembedModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/oembed/constants/index.ts
+++ b/src/oembed/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './oembed-error-message';

--- a/src/oembed/constants/oembed-error-message.ts
+++ b/src/oembed/constants/oembed-error-message.ts
@@ -1,0 +1,3 @@
+export const OEMBED_ERROR_MSG = {
+  FAIL_TO_FETCH_OEMBED_SPEC: 'spec 데이터를 가져오는 데 실패하였습니다',
+};

--- a/src/oembed/interfaces/index.ts
+++ b/src/oembed/interfaces/index.ts
@@ -1,0 +1,1 @@
+export * from './oembed-spec-list.interface';

--- a/src/oembed/interfaces/oembed-spec-list.interface.ts
+++ b/src/oembed/interfaces/oembed-spec-list.interface.ts
@@ -1,0 +1,12 @@
+export interface OembedSpecList {
+  provider_name: string;
+  provider_url: string;
+  endpoints: Endpoint[];
+}
+
+interface Endpoint {
+  schemes?: string[];
+  url: string;
+  formats?: string[];
+  discovery?: boolean;
+}

--- a/src/oembed/oembed.controller.spec.ts
+++ b/src/oembed/oembed.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OembedController } from './oembed.controller';
+
+describe('OembedController', () => {
+  let controller: OembedController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [OembedController],
+    }).compile();
+
+    controller = module.get<OembedController>(OembedController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/oembed/oembed.controller.ts
+++ b/src/oembed/oembed.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('oembed')
+export class OembedController {}

--- a/src/oembed/oembed.module.ts
+++ b/src/oembed/oembed.module.ts
@@ -1,0 +1,16 @@
+import { HttpModule } from '@nestjs/axios';
+import { Module } from '@nestjs/common';
+import { OembedController } from './oembed.controller';
+import { OembedService } from './oembed.service';
+
+@Module({
+  imports: [
+    HttpModule.register({
+      timeout: 5000,
+      maxRedirects: 5,
+    }),
+  ],
+  controllers: [OembedController],
+  providers: [OembedService],
+})
+export class OembedModule {}

--- a/src/oembed/oembed.service.spec.ts
+++ b/src/oembed/oembed.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OembedService } from './oembed.service';
+
+describe('OembedService', () => {
+  let service: OembedService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [OembedService],
+    }).compile();
+
+    service = module.get<OembedService>(OembedService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/oembed/oembed.service.ts
+++ b/src/oembed/oembed.service.ts
@@ -7,10 +7,10 @@ import { OembedSpecList } from './interfaces';
 
 @Injectable()
 export class OembedService {
-  oembedSpecList: Promise<OembedSpecList[]>;
+  oembedSpecList: OembedSpecList[];
   constructor(private httpService: HttpService) {}
 
-  async getOembedSpec(): Promise<OembedSpecList[]> {
+  async getOembedSpecList(): Promise<OembedSpecList[]> {
     const oembedSpecUrl = 'https://oembed.com/providers.json';
     const observer = this.httpService
       .get(oembedSpecUrl)
@@ -20,5 +20,12 @@ export class OembedService {
         OEMBED_ERROR_MSG.FAIL_TO_FETCH_OEMBED_SPEC,
       );
     });
+  }
+
+  async setOembedSpecList(): Promise<void> {
+    if (this.oembedSpecList) {
+      return;
+    }
+    this.oembedSpecList = await this.getOembedSpecList();
   }
 }

--- a/src/oembed/oembed.service.ts
+++ b/src/oembed/oembed.service.ts
@@ -1,21 +1,24 @@
 import { HttpService } from '@nestjs/axios';
-import { Injectable } from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { lastValueFrom, map } from 'rxjs';
 
+import { OEMBED_ERROR_MSG } from './constants';
 import { OembedSpecList } from './interfaces';
 
 @Injectable()
 export class OembedService {
   oembedSpecList: Promise<OembedSpecList[]>;
-  constructor(private httpService: HttpService) {
-    this.oembedSpecList = this.getOembedSpec();
-  }
+  constructor(private httpService: HttpService) {}
 
   async getOembedSpec(): Promise<OembedSpecList[]> {
     const oembedSpecUrl = 'https://oembed.com/providers.json';
     const observer = this.httpService
       .get(oembedSpecUrl)
       .pipe(map((axiosResponse) => axiosResponse.data));
-    return await lastValueFrom(observer);
+    return await lastValueFrom(observer).catch(() => {
+      throw new InternalServerErrorException(
+        OEMBED_ERROR_MSG.FAIL_TO_FETCH_OEMBED_SPEC,
+      );
+    });
   }
 }

--- a/src/oembed/oembed.service.ts
+++ b/src/oembed/oembed.service.ts
@@ -1,0 +1,21 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable } from '@nestjs/common';
+import { lastValueFrom, map } from 'rxjs';
+
+import { OembedSpecList } from './interfaces';
+
+@Injectable()
+export class OembedService {
+  oembedSpecList: Promise<OembedSpecList[]>;
+  constructor(private httpService: HttpService) {
+    this.oembedSpecList = this.getOembedSpec();
+  }
+
+  async getOembedSpec(): Promise<OembedSpecList[]> {
+    const oembedSpecUrl = 'https://oembed.com/providers.json';
+    const observer = this.httpService
+      .get(oembedSpecUrl)
+      .pipe(map((axiosResponse) => axiosResponse.data));
+    return await lastValueFrom(observer);
+  }
+}


### PR DESCRIPTION
## 개요

oEmbed spec 가져오기 구현

## 세부내용

- https://oembed.com/providers.json 페이지의 데이터를 가져옵니다.
- 가져온 데이터는 OembedService에서 사용할 수 있도록 oembedSpecList에 저장합니다.

## 관련 이슈

#1 
