### PR TITLE
refactor: UrlDto

### DIFF
--- a/src/oembed/constants/oembed-error-message.ts
+++ b/src/oembed/constants/oembed-error-message.ts
@@ -1,5 +1,5 @@
 export const OEMBED_ERROR_MSG = {
   FAIL_TO_FETCH_OEMBED_SPEC: 'spec 데이터를 가져오는 데 실패하였습니다',
   EMPTY_URL: 'url을 반드시 입력해야 합니다',
-  INVALID_URL: '올바른 url 형태가 아닙니다(ex: http://youtube.com)',
+  INVALID_URL: '올바른 url 형태가 아닙니다(ex: https://youtube.com)',
 };

--- a/src/oembed/dto/url.dto.ts
+++ b/src/oembed/dto/url.dto.ts
@@ -3,6 +3,9 @@ import { OEMBED_ERROR_MSG } from '../constants';
 
 export class UrlDto {
   @IsString({ message: OEMBED_ERROR_MSG.EMPTY_URL })
-  @IsUrl({ require_protocol: true }, { message: OEMBED_ERROR_MSG.INVALID_URL })
+  @IsUrl(
+    { protocols: ['http', 'https'] },
+    { message: OEMBED_ERROR_MSG.INVALID_URL },
+  )
   url: string;
 }


### PR DESCRIPTION
## 개요

UrlDto 코드 수정

## 세부내용

- UrlDto 유효성 검사에서 url에 http, https 프로토콜만 들어올 수 있도록 수정
이전에는 아래와 같이 올바른 형태의 프로토콜을 적기만 하면 요청이 가능하도록 되어 있었습니다.
<img src="https://user-images.githubusercontent.com/51621520/146186851-e771f284-6349-4f17-99d5-761e9acb87ec.png" width=60% />

그러나 http, https만 허용해야 한다고 판단하여 두 개의 프로토콜이 아닌 경우 에러 메시지를 반환하도록 수정하였습니다.
<img src="https://user-images.githubusercontent.com/51621520/146186763-8218334b-4bdf-4270-bfa7-f6b94394d484.png" width=60% />

## 관련 이슈
없음
