### PR TITLE
feat: get matched oembed spec

### DIFF
--- a/src/oembed/constants/oembed-error-message.ts
+++ b/src/oembed/constants/oembed-error-message.ts
@@ -2,4 +2,5 @@ export const OEMBED_ERROR_MSG = {
   FAIL_TO_FETCH_OEMBED_SPEC: 'spec 데이터를 가져오는 데 실패하였습니다',
   EMPTY_URL: 'url을 반드시 입력해야 합니다',
   INVALID_URL: '올바른 url 형태가 아닙니다(ex: https://youtube.com)',
+  NOT_MATCH_PROVIDER: '일치하는 provider가 존재하지 않습니다',
 };

--- a/src/oembed/interfaces/index.ts
+++ b/src/oembed/interfaces/index.ts
@@ -1,1 +1,2 @@
 export * from './oembed-spec-list.interface';
+export * from './oembed-spec-endpoint-url-and-schemes.interface';

--- a/src/oembed/interfaces/oembed-spec-endpoint-url-and-schemes.interface.ts
+++ b/src/oembed/interfaces/oembed-spec-endpoint-url-and-schemes.interface.ts
@@ -1,0 +1,4 @@
+export interface OembedSpecEndpointUrlAndSchemes {
+  schemes: string[];
+  url: string;
+}

--- a/src/oembed/oembed.service.ts
+++ b/src/oembed/oembed.service.ts
@@ -4,11 +4,11 @@ import { lastValueFrom, map } from 'rxjs';
 
 import { OEMBED_ERROR_MSG } from './constants';
 import { UrlDto } from './dto/url.dto';
-import { OembedSpecList } from './interfaces';
+import { OembedSpecEndpointUrlAndSchemes, OembedSpecList } from './interfaces';
 
 @Injectable()
 export class OembedService {
-  oembedSpecList: OembedSpecList[];
+  oembedSpecEndpointUrlAndSchemesList: OembedSpecEndpointUrlAndSchemes[];
   constructor(private httpService: HttpService) {}
 
   async getOembedSpecList(): Promise<OembedSpecList[]> {
@@ -23,15 +23,33 @@ export class OembedService {
     });
   }
 
-  async setOembedSpecList(): Promise<void> {
-    if (this.oembedSpecList) {
+  async setOembedSpecEndpointUrlAndSchemesList(): Promise<void> {
+    if (this.oembedSpecEndpointUrlAndSchemesList) {
       return;
     }
-    this.oembedSpecList = await this.getOembedSpecList();
+
+    const specList = await this.getOembedSpecList();
+    this.oembedSpecEndpointUrlAndSchemesList = [];
+
+    for (const spec of specList) {
+      for (const endpoint of spec.endpoints) {
+        const schemesList = [];
+
+        endpoint.schemes?.map((scheme) => {
+          const newScheme = scheme.replace(/\./g, '\\.').replace(/\*/g, '\\w');
+          schemesList.push(new RegExp(newScheme));
+        });
+
+        this.oembedSpecEndpointUrlAndSchemesList.push({
+          schemes: schemesList,
+          url: endpoint.url.replace('{format}', 'json'),
+        });
+      }
+    }
   }
 
   async getOembedData(urlDto: UrlDto): Promise<string> {
-    await this.setOembedSpecList();
+    await this.setOembedSpecEndpointUrlAndSchemesList();
 
     const urlStartIndex = urlDto.url.indexOf('//') + 2;
     const url = urlDto.url.substring(urlStartIndex);


### PR DESCRIPTION
## 개요

url과 일치하는 provider를 찾는 기능 구현

## 세부내용

- oembed spec에서 endpoint url과 schemes를 추출한 뒤 배열에 저장
- scheme은 정규식으로 만들어서(`new RegExp(scheme)`) url과 `search` 함수를 통해 비교
- url과 일치하는 scheme을 찾아서 해당 provider를 반환
만약 일치하는 provider가 없는 경우 400 에러를 반환
<img src="https://user-images.githubusercontent.com/51621520/146366763-679d3535-8ec1-405a-8b96-4528e49cb9e3.png" width=60% />

## 관련 이슈

#8 
