### PR TITLE
feat: get oEmbed data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+# env
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@nestjs/axios": "^0.0.3",
         "@nestjs/common": "^8.0.0",
+        "@nestjs/config": "^1.1.5",
         "@nestjs/core": "^8.0.0",
         "@nestjs/platform-express": "^8.0.0",
         "class-transformer": "^0.5.1",
@@ -1371,6 +1372,24 @@
         "class-validator": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/config": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-1.1.5.tgz",
+      "integrity": "sha512-xSpp/6TIHFhicuuwRu2fFGmClzN+YXtpVSLGX3LT9iAwtNDcccX3qVDOX1BLdFdBbqZTqT3KezsT+iE/czd/xg==",
+      "dependencies": {
+        "dotenv": "10.0.0",
+        "dotenv-expand": "5.1.0",
+        "lodash.get": "4.4.2",
+        "lodash.has": "4.5.2",
+        "lodash.set": "4.3.2",
+        "uuid": "8.3.2"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0",
+        "reflect-metadata": "^0.1.13",
+        "rxjs": "^6.0.0 || ^7.2.0"
       }
     },
     "node_modules/@nestjs/core": {
@@ -3477,6 +3496,19 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -6192,6 +6224,16 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "node_modules/lodash.has": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -6203,6 +6245,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -9890,6 +9937,19 @@
         "uuid": "8.3.2"
       }
     },
+    "@nestjs/config": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-1.1.5.tgz",
+      "integrity": "sha512-xSpp/6TIHFhicuuwRu2fFGmClzN+YXtpVSLGX3LT9iAwtNDcccX3qVDOX1BLdFdBbqZTqT3KezsT+iE/czd/xg==",
+      "requires": {
+        "dotenv": "10.0.0",
+        "dotenv-expand": "5.1.0",
+        "lodash.get": "4.4.2",
+        "lodash.has": "4.5.2",
+        "lodash.set": "4.3.2",
+        "uuid": "8.3.2"
+      }
+    },
     "@nestjs/core": {
       "version": "8.2.3",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-8.2.3.tgz",
@@ -11532,6 +11592,16 @@
           "dev": true
         }
       }
+    },
+    "dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+    },
+    "dotenv-expand": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
     },
     "ee-first": {
       "version": "1.1.1",
@@ -13590,6 +13660,16 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.has": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -13601,6 +13681,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "log-symbols": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@nestjs/axios": "^0.0.3",
     "@nestjs/common": "^8.0.0",
+    "@nestjs/config": "^1.1.5",
     "@nestjs/core": "^8.0.0",
     "@nestjs/platform-express": "^8.0.0",
     "class-transformer": "^0.5.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,11 +1,17 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { OembedModule } from './oembed/oembed.module';
 
 @Module({
-  imports: [OembedModule],
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+    }),
+    OembedModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,6 @@ import { AppModule } from './app.module';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.useGlobalPipes(new ValidationPipe());
-  await app.listen(3000);
+  await app.listen(process.env.PORT || 3000);
 }
 bootstrap();

--- a/src/oembed/constants/oembed-error-message.ts
+++ b/src/oembed/constants/oembed-error-message.ts
@@ -3,4 +3,5 @@ export const OEMBED_ERROR_MSG = {
   EMPTY_URL: 'url을 반드시 입력해야 합니다',
   INVALID_URL: '올바른 url 형태가 아닙니다(ex: https://youtube.com)',
   NOT_MATCH_PROVIDER: '일치하는 provider가 존재하지 않습니다',
+  FAIL_TO_FETCH_OEMBED_DATA: 'oembed 정보를 가져오는 것에 실패하였습니다',
 };

--- a/src/oembed/oembed.controller.ts
+++ b/src/oembed/oembed.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Post } from '@nestjs/common';
+
 import { UrlDto } from './dto/url.dto';
 import { OembedService } from './oembed.service';
 
@@ -7,7 +8,7 @@ export class OembedController {
   constructor(private oembedService: OembedService) {}
 
   @Post()
-  async getOembedData(@Body() urlDto: UrlDto): Promise<string> {
+  async getOembedData(@Body() urlDto: UrlDto): Promise<any> {
     return await this.oembedService.getOembedData(urlDto);
   }
 }

--- a/src/oembed/oembed.module.ts
+++ b/src/oembed/oembed.module.ts
@@ -1,5 +1,7 @@
 import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+
 import { OembedController } from './oembed.controller';
 import { OembedService } from './oembed.service';
 
@@ -9,6 +11,7 @@ import { OembedService } from './oembed.service';
       timeout: 5000,
       maxRedirects: 5,
     }),
+    ConfigModule,
   ],
   controllers: [OembedController],
   providers: [OembedService],

--- a/src/oembed/oembed.service.ts
+++ b/src/oembed/oembed.service.ts
@@ -60,7 +60,16 @@ export class OembedService {
     if (!matchedOembedSpec) {
       throw new BadRequestException(OEMBED_ERROR_MSG.NOT_MATCH_PROVIDER);
     }
-    return url;
+
+    const newUrl = matchedOembedSpec.url + `?url=${url}`;
+    const observer = this.httpService
+      .get(newUrl)
+      .pipe(map((axiosResponse) => axiosResponse.data));
+    return await lastValueFrom(observer).catch(() => {
+      throw new InternalServerErrorException(
+        OEMBED_ERROR_MSG.FAIL_TO_FETCH_OEMBED_DATA,
+      );
+    });
   }
 
   getMatchedOembedSpec(url: string): OembedSpecEndpointUrlAndSchemes {

--- a/src/oembed/oembed.service.ts
+++ b/src/oembed/oembed.service.ts
@@ -40,7 +40,7 @@ export class OembedService {
         const schemesList = [];
 
         endpoint.schemes?.map((scheme) => {
-          const newScheme = scheme.replace(/\./g, '\\.').replace(/\*/g, '\\w');
+          const newScheme = scheme.replace(/\./g, '\\.').replace(/\*/g, '.+');
           schemesList.push(new RegExp(newScheme));
         });
 

--- a/src/oembed/oembed.service.ts
+++ b/src/oembed/oembed.service.ts
@@ -4,6 +4,7 @@ import {
   Injectable,
   InternalServerErrorException,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { lastValueFrom, map } from 'rxjs';
 
 import { OEMBED_ERROR_MSG } from './constants';
@@ -13,7 +14,10 @@ import { OembedSpecEndpointUrlAndSchemes, OembedSpecList } from './interfaces';
 @Injectable()
 export class OembedService {
   oembedSpecEndpointUrlAndSchemesList: OembedSpecEndpointUrlAndSchemes[];
-  constructor(private httpService: HttpService) {}
+  constructor(
+    private httpService: HttpService,
+    private configService: ConfigService,
+  ) {}
 
   async getOembedSpecList(): Promise<OembedSpecList[]> {
     const oembedSpecUrl = 'https://oembed.com/providers.json';
@@ -52,7 +56,7 @@ export class OembedService {
     }
   }
 
-  async getOembedData(urlDto: UrlDto): Promise<string> {
+  async getOembedData(urlDto: UrlDto): Promise<any> {
     await this.setOembedSpecEndpointUrlAndSchemesList();
 
     const url = urlDto.url;
@@ -61,7 +65,14 @@ export class OembedService {
       throw new BadRequestException(OEMBED_ERROR_MSG.NOT_MATCH_PROVIDER);
     }
 
-    const newUrl = matchedOembedSpec.url + `?url=${url}`;
+    let newUrl = matchedOembedSpec.url + `?url=${url}`;
+    if (matchedOembedSpec.url.includes('facebook')) {
+      const appId = this.configService.get<string>('FACEBOOK_APP_ID');
+      const clientToken = this.configService.get<string>(
+        'FACEBOOK_CLIENT_TOKEN',
+      );
+      newUrl += `&access_token=${appId}|${clientToken}`;
+    }
     const observer = this.httpService
       .get(newUrl)
       .pipe(map((axiosResponse) => axiosResponse.data));


### PR DESCRIPTION
## 개요

oEmbed data 가져오기 구현

## 세부내용

- oEmbed를 제공하는 서비스에서 url에 관련된 데이터를 가져오는 기능 구현
- facebook의 경우 oEmbed 데이터를 읽기 위한 권한(oEmbed read)이 필요하며, 권한이 있는 app ID와 client token을 access_token으로 묶어 서비스에 데이터를 요청할 때 url에 붙여서 요청을 보내야 합니다.
(ex: https://graph.facebook.com/v10.0/instagram_oembed?url={url}&access_token={app_id}|{client_token})
이에 대해 프로젝트의 루트 폴더에 `.env` 파일을 생성하여 `FACEBOOK_APP_ID={app_id}`, `FACEBOOK_CLIENT_TOKEN={client_token}`을 작성하여 애플리케이션에서 app_id와 client_token을 쓸 수 있도록 설정하거나, 환경변수를 정의하여 app_id와 client_token을 설정할 수 있습니다.

## 관련 이슈

#10 
